### PR TITLE
Feature/circlecli integration

### DIFF
--- a/.circleci
+++ b/.circleci
@@ -1,0 +1,8 @@
+version: 2
+jobs:
+   build:
+     docker:
+       - image: circleci/openjdk:8-jdk-node-browsers
+     steps:
+       - checkout
+       - run: echo "hello world"

--- a/.circleci
+++ b/.circleci
@@ -1,8 +1,0 @@
-version: 2
-jobs:
-   build:
-     docker:
-       - image: circleci/openjdk:8-jdk-node-browsers
-     steps:
-       - checkout
-       - run: echo "hello world"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+# Java Gradle CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-java/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+    
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.gradle" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: gradle dependencies
+
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+        
+      # run tests!
+      - run: gradle test
+
+
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - checkout
       - run:
-        name: Update gradle
-        command: 'sudo sdk install gradle 4.5'
+          name: Update gradle 
+          command: 'sudo sdk install gradle 4.5'
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,9 @@ jobs:
       - checkout
       - run:
           name: Update gradle 
-          command: 'sudo sdk install gradle 4.5'
+          command: 'sudo add-apt-repository ppa:cwchien/gradle'
+          command: 'sudo apt-get update'
+          command: 'sudo apt upgrade gradle'
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,9 @@ jobs:
     
     steps:
       - checkout
-
+      - run:
+        name: Update gradle
+        command: 'sudo sdk install gradle 4.5'
       # Download and cache dependencies
       - restore_cache:
           keys:


### PR DESCRIPTION
- added a circle cli 2.0 config
- had to change circle cli's default gradle to a more up-to-date version to stop an error on gradle dependency of:  
configuration 'detachedConfiguration2' declares a dependency on configuration 'default' which is not declared